### PR TITLE
Add guards for query cache mapping

### DIFF
--- a/components/PostContent.tsx
+++ b/components/PostContent.tsx
@@ -93,7 +93,8 @@ export default function PostContent({ post, detail = false }: PostContentProps) 
                         queryClient.setQueryData<InfiniteData<Post[]>>([
                                 "free_boards",
                         ], (oldData) => {
-                                if (!oldData) return oldData;
+                                if (!oldData || !Array.isArray(oldData.pages))
+                                        return oldData;
                                 return {
                                         ...oldData,
                                         pages: oldData.pages.map((page) =>
@@ -170,7 +171,8 @@ export default function PostContent({ post, detail = false }: PostContentProps) 
                         queryClient.setQueryData<InfiniteData<Post[]>>([
                                 "free_boards",
                         ], (oldData) => {
-                                if (!oldData) return oldData;
+                                if (!oldData || !Array.isArray(oldData.pages))
+                                        return oldData;
                                 return {
                                         ...oldData,
                                         pages: oldData.pages.map((page) =>

--- a/components/PostDetail.tsx
+++ b/components/PostDetail.tsx
@@ -45,7 +45,8 @@ export default function PostDetail({ postId }) {
                         queryClient.setQueryData<InfiniteData<FreeBoardsRow[]>>(
                                 ["free_boards"],
                                 (oldData) => {
-                                        if (!oldData) return oldData;
+                                        if (!oldData || !Array.isArray(oldData.pages))
+                                                return oldData;
                                         return {
                                                 ...oldData,
                                                 pages: oldData.pages.map((page) =>


### PR DESCRIPTION
## Summary
- Guard React Query cache updates in PostDetail to ensure oldData pages exist
- Add similar checks for like and delete cache mutations in PostContent

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration interaction)


------
https://chatgpt.com/codex/tasks/task_e_68be8d3019d48331a3b2b0effb9202db