### PR TITLE
fix: give loader sentinel height

### DIFF
--- a/components/FreeBoards.tsx
+++ b/components/FreeBoards.tsx
@@ -68,7 +68,11 @@ export default function FreeBoards() {
                                         <PostContentSkeleton />
                                 </>
                         )}
-                        <div ref={loaderRef} />
+                        <div
+                                ref={loaderRef}
+                                className="h-1"
+                                aria-hidden="true"
+                        />
                 </>
         );
 }


### PR DESCRIPTION
## Summary
- ensure FreeBoards loader sentinel has non-zero height for intersection observer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for Next.js ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68be92c1ddec8331909db7ba2c14693e